### PR TITLE
Update prod values to reflect sidecar transformer settings

### DIFF
--- a/servicex-prod-uproot/values.yaml
+++ b/servicex-prod-uproot/values.yaml
@@ -37,7 +37,6 @@ spec:
         
     # Settings for the Flask App
     app:
-      image: sslhep/servicex_app
       # tag: develop
       adminEmail: bengal1@illinois.edu
       pullPolicy: Always
@@ -86,7 +85,6 @@ spec:
 
     # Settings for the DID Finder
     didFinder:
-      image: sslhep/servicex-did-finder
       rucio:
         enabled: true
         # tag: develop
@@ -104,7 +102,6 @@ spec:
 
       CERNOpenData:
         enabled: false
-        image: sslhep/servicex-did-finder-cernopendata
           # tag: develop
         pullPolicy: Always
             
@@ -113,10 +110,11 @@ spec:
     # Code Generator service
     codeGen:
       enabled: true
-      # image: sslhep/servicex_code_gen_func_adl_xaod
-      # For uproot deployment
       image: sslhep/servicex_code_gen_func_adl_uproot
       pullPolicy: Always
+      defaultScienceContainerImage: sslhep/servicex_func_adl_uproot_transformer
+      defaultScienceContainerTag: v1.1.4
+
 
     # Pull policy for the worker pods - the image and version are specified as
     # part of the transform request
@@ -128,10 +126,11 @@ spec:
         maxReplicas: 750
       # pullPolicy: Always
       cpuLimit: 1
-      defaultTransformerImage: sslhep/servicex_func_adl_uproot_transformer
-      # defaultTransformerTag:20220309-1723-stable
-      language: bash
-      exec: /generated/transform_single_file.sh
+
+      # Settings for the uproot transformer science container
+      language: python
+      exec: /generated/transform_single_file.py
+
     # Values for the Postgresql Chart
     postgres:
       enabled: true

--- a/servicex-prod-xaod/values.yaml
+++ b/servicex-prod-xaod/values.yaml
@@ -33,7 +33,6 @@ spec:
 
     # Settings for the Flask App
     app:
-      # image: sslhep/servicex_app
       # tag: "develop"
       adminEmail: bengal1@illinois.edu
       # pullPolicy: Always
@@ -82,8 +81,6 @@ spec:
 
     # Settings for the DID Finder
     didFinder:
-      image: sslhep/servicex-did-finder
-        #      image: sslhep/servicex-did-finder-cernopendata
       rucio:
         enabled: true
         # tag: develop
@@ -106,6 +103,9 @@ spec:
     codeGen:
       enabled: true
       image: sslhep/servicex_code_gen_atlas_xaod
+      defaultScienceContainerImage: sslhep/sslhep/servicex_func_adl_xaod_transformer
+      defaultScienceContainerTag: v1.1.4
+
 
     # Pull policy for the worker pods - the image and version are specified as
     # part of the transform request
@@ -117,7 +117,6 @@ spec:
         maxReplicas: 750
       # pullPolicy: Always
       cpuLimit: 1
-      defaultTransformerImage: sslhep/servicex_func_adl_xaod_transformer
       language: bash
       exec: /generated/transform_single_file.sh       
 


### PR DESCRIPTION
There were a couple of misconfigurations for the prod river deployments. This corrects them and removes some obsolete values.